### PR TITLE
Issue 110: DeclarativePipeline, simplify creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- [Issue #110](https://github.com/manheim/jenkinsfile-pipeline/issues/110): Simplify DeclarativePipeline constructor
+
 ## v1.1
 
 - [Issue #103](https://github.com/manheim/jenkinsfile-pipeline/issues/103): BuildStage: Ability to customize build command

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ jenkinsfile-pipeline attempts to abstract away these two different types of pipe
 
 You can convert to a DeclarativePipeline by instantiating it in place of a Scripted one.
 ```
-def pipeline = new DeclarativePipeline(this)
+def pipeline = new DeclarativePipeline()
 ```
 
 A short-coming of Declarative Pipelines is the inability to use variables when defining Stage names (See: [JENKINS-43820](https://issues.jenkins-ci.org/browse/JENKINS-43820)).  The compromise made by terraform-pipeline is to name each of the top-level Stage names using consecutive numbers '1', '2', '3', etc.  The following code:
@@ -271,7 +271,7 @@ A short-coming of Declarative Pipelines is the inability to use variables when d
 Customizations.init()
 Jenkinsfile.init(this)
 
-def pipeline = new DeclarativePipeline(this)
+def pipeline = new DeclarativePipeline()
 def buildArtifact = new BuildStage()
 def deployQa = new DeployStage('qa')
 def deployUat = new DeployStage('uat')

--- a/src/DeclarativePipeline.groovy
+++ b/src/DeclarativePipeline.groovy
@@ -2,6 +2,7 @@ class DeclarativePipeline {
     private workflowScript
     private List<Stage> stages = []
 
+    // Remove workflowScript argument as part of Issue #111
     public DeclarativePipeline(workflowScript = null) {
         this.workflowScript = Jenkinsfile.getInstance()
     }

--- a/src/DeclarativePipeline.groovy
+++ b/src/DeclarativePipeline.groovy
@@ -2,8 +2,8 @@ class DeclarativePipeline {
     private workflowScript
     private List<Stage> stages = []
 
-    public DeclarativePipeline(workflowScript) {
-        this.workflowScript = workflowScript
+    public DeclarativePipeline(workflowScript = null) {
+        this.workflowScript = Jenkinsfile.getInstance()
     }
 
     public DeclarativePipeline startsWith(Stage stage) {

--- a/src/DeclarativePipeline.groovy
+++ b/src/DeclarativePipeline.groovy
@@ -1,10 +1,8 @@
 class DeclarativePipeline {
-    private workflowScript
     private List<Stage> stages = []
 
     // Remove workflowScript argument as part of Issue #111
     public DeclarativePipeline(workflowScript = null) {
-        this.workflowScript = Jenkinsfile.getInstance()
     }
 
     public DeclarativePipeline startsWith(Stage stage) {
@@ -24,6 +22,8 @@ class DeclarativePipeline {
     }
 
     public getPipelineTemplate(List<Stage> stages) {
+        def workflowScript = Jenkinsfile.getInstance()
+
         switch (stages.size()) {
             case 0:
                 return workflowScript.Pipeline0Stage

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -26,6 +26,10 @@ public class Jenkinsfile implements Resettable {
         return this
     }
 
+    public static withWorkflowScript(workflowScript) {
+        this.original = workflowScript
+    }
+
     public static reset() {
         this.original = null
         this.shouldInitializeDefaultPlugins = true

--- a/test/DeclarativePipelineTest.groovy
+++ b/test/DeclarativePipelineTest.groovy
@@ -12,6 +12,11 @@ class DeclarativePipelineTest {
     @Nested
     public class Constructor {
         @Test
+        void doesNotError() {
+            def pipeline = new DeclarativePipeline()
+        }
+
+        @Test
         void deprecatedAcceptsAWorkflowScript() {
             def workflowScript = new MockWorkflowScript()
             def pipeline = new DeclarativePipeline(workflowScript)

--- a/test/DeclarativePipelineTest.groovy
+++ b/test/DeclarativePipelineTest.groovy
@@ -85,7 +85,8 @@ class DeclarativePipelineTest {
             def expectedTemplate = { }
             def workflowScript = new PipelineTemplateMockWorkflowScript()
             workflowScript.Pipeline0Stage = expectedTemplate
-            def pipeline = new DeclarativePipeline(workflowScript)
+            Jenkinsfile.withWorkflowScript(workflowScript)
+            def pipeline = new DeclarativePipeline()
 
             def result = pipeline.getPipelineTemplate([])
 
@@ -97,7 +98,8 @@ class DeclarativePipelineTest {
             def expectedTemplate = { }
             def workflowScript = new PipelineTemplateMockWorkflowScript()
             workflowScript.Pipeline1Stage = expectedTemplate
-            def pipeline = new DeclarativePipeline(workflowScript)
+            Jenkinsfile.withWorkflowScript(workflowScript)
+            def pipeline = new DeclarativePipeline()
 
             def result = pipeline.getPipelineTemplate([mock(Stage)])
 
@@ -109,7 +111,8 @@ class DeclarativePipelineTest {
             def expectedTemplate = { }
             def workflowScript = new PipelineTemplateMockWorkflowScript()
             workflowScript.Pipeline2Stage = expectedTemplate
-            def pipeline = new DeclarativePipeline(workflowScript)
+            Jenkinsfile.withWorkflowScript(workflowScript)
+            def pipeline = new DeclarativePipeline()
 
             def stages = (1..2).collect { mock(Stage) }
             def result = pipeline.getPipelineTemplate(stages)
@@ -122,7 +125,8 @@ class DeclarativePipelineTest {
             def expectedTemplate = { }
             def workflowScript = new PipelineTemplateMockWorkflowScript()
             workflowScript.Pipeline3Stage = expectedTemplate
-            def pipeline = new DeclarativePipeline(workflowScript)
+            Jenkinsfile.withWorkflowScript(workflowScript)
+            def pipeline = new DeclarativePipeline()
 
             def stages = (1..3).collect { mock(Stage) }
             def result = pipeline.getPipelineTemplate(stages)
@@ -135,7 +139,8 @@ class DeclarativePipelineTest {
             def expectedTemplate = { }
             def workflowScript = new PipelineTemplateMockWorkflowScript()
             workflowScript.Pipeline4Stage = expectedTemplate
-            def pipeline = new DeclarativePipeline(workflowScript)
+            Jenkinsfile.withWorkflowScript(workflowScript)
+            def pipeline = new DeclarativePipeline()
 
             def stages = (1..4).collect { mock(Stage) }
             def result = pipeline.getPipelineTemplate(stages)
@@ -148,7 +153,8 @@ class DeclarativePipelineTest {
             def expectedTemplate = { }
             def workflowScript = new PipelineTemplateMockWorkflowScript()
             workflowScript.Pipeline5Stage = expectedTemplate
-            def pipeline = new DeclarativePipeline(workflowScript)
+            Jenkinsfile.withWorkflowScript(workflowScript)
+            def pipeline = new DeclarativePipeline()
 
             def stages = (1..5).collect { mock(Stage) }
             def result = pipeline.getPipelineTemplate(stages)
@@ -161,7 +167,8 @@ class DeclarativePipelineTest {
             def expectedTemplate = { }
             def workflowScript = new PipelineTemplateMockWorkflowScript()
             workflowScript.Pipeline6Stage = expectedTemplate
-            def pipeline = new DeclarativePipeline(workflowScript)
+            Jenkinsfile.withWorkflowScript(workflowScript)
+            def pipeline = new DeclarativePipeline()
 
             def stages = (1..6).collect { mock(Stage) }
             def result = pipeline.getPipelineTemplate(stages)
@@ -174,7 +181,8 @@ class DeclarativePipelineTest {
             def expectedTemplate = { }
             def workflowScript = new PipelineTemplateMockWorkflowScript()
             workflowScript.Pipeline7Stage = expectedTemplate
-            def pipeline = new DeclarativePipeline(workflowScript)
+            Jenkinsfile.withWorkflowScript(workflowScript)
+            def pipeline = new DeclarativePipeline()
 
             def stages = (1..7).collect { mock(Stage) }
             def result = pipeline.getPipelineTemplate(stages)

--- a/test/DeclarativePipelineTest.groovy
+++ b/test/DeclarativePipelineTest.groovy
@@ -16,6 +16,7 @@ class DeclarativePipelineTest {
             def pipeline = new DeclarativePipeline()
         }
 
+        // Remove this as part of Issue #111
         @Test
         void deprecatedAcceptsAWorkflowScript() {
             def workflowScript = new MockWorkflowScript()

--- a/test/DeclarativePipelineTest.groovy
+++ b/test/DeclarativePipelineTest.groovy
@@ -12,7 +12,7 @@ class DeclarativePipelineTest {
     @Nested
     public class Constructor {
         @Test
-        void acceptsAWorkflowScript() {
+        void deprecatedAcceptsAWorkflowScript() {
             def workflowScript = new MockWorkflowScript()
             def pipeline = new DeclarativePipeline(workflowScript)
         }


### PR DESCRIPTION
The constructor for DeclarativePipeline takes in an instance of the workflowscript.  There's no reason to do that, it's available when we do `Jenkinsfile.init(this)`.  Use the one captured by `Jenkinsfile.init(this)` instead.

## Merge Checklist

* [x] Have you linked this Pull Request to an [Issue](https://github.com/manheim/jenkinsfile-pipeline/issues)?
* [x] Have you updated any relevant README files, to explain how this new feature works (with examples)?
* [x] Have you added relevant test cases for your change?
* [x] Do all tests and code style checks pass with `./gradlew check --info`?
* [x] Have you successfully run your change in a pipeline in a Jenkins instance?
* [x] Have you updated the [CHANGELOG](https://github.com/manheim/jenkinsfile-pipeline/blob/master/CHANGELOG.md)?
