### PR TITLE
Issue 112: Refactor: BuildStage/DeployStage, turn stage into a Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- [Issue #112](https://github.com/manheim/jenkinsfile-pipeline/issues/112): Refactor: BuildStage/DeployStage, turn hardcoded stage into a Plugin
 - [Issue #110](https://github.com/manheim/jenkinsfile-pipeline/issues/110): Simplify DeclarativePipeline constructor
 
 ## v1.1

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The example above gives you a bare-bones pipeline, and there may be Jenkinsfile 
 * [DefaultEnvironmentPlugin](./docs/DefaultEnvironmentPlugin.md): Provide an environment variable containing the DeployStage's environment.
 * [NodePlugin](./docs/NodePlugin.md): Control where jobs are run
 * [ScmPlugin](./docs/ScmPlugin.md): Checkout the project's code
+* [StageDisplayPlugin](./docs/StageDisplayPlugin.md): Wraps each Stage with Jenkinsfile DSL `stage`
 
 ### Build Artifact Management
 * [StashUnstashPlugin](./docs/StashUnstashPlugin.md): Stash your artifact after BuildStage, and unstash it for each of your subsequent DeployStages.

--- a/docs/StageDisplayPlugin.md
+++ b/docs/StageDisplayPlugin.md
@@ -1,0 +1,46 @@
+## [StageDisplayPlugin](../src/StageDisplayPlugin.groovy)
+
+This plugin is enabled by default.
+
+Wraps each Stage with Jenkinsfile DSL `stage`, and determines the name displayed by each Stage.
+
+```
+@Library('jenkinsfile-pipeline@<VERSION>') _
+
+// StageDisplayPlugin.init() is called in Jenkinsfile.init(this)
+// This wraps your pipeline Stages with Jenkinsfile stage { }
+Jenkinsfile.init(this)
+
+def pipeline = new ScriptedPipeline()
+def buildArtifact = new BuildStage()
+def deployQa = new DeployStage('qa')
+def deployUat = new DeployStage('uat')
+def deployProd = new DeployStage('prod')
+
+pipeline.startsWith(buildArtifact)
+        .then(deployQa)
+        .then(deployUat)
+        .then(deployProd)
+        .build()
+```
+
+This plugin can be disabled, and is useful for DeclarativePipelines that use templates to determine stage names.
+
+```
+@Library('jenkinsfile-pipeline@<VERSION>') _
+
+StageDisplayPlugin.disable()
+Jenkinsfile.init(this)
+
+def pipeline = new DeclarativePipeline()
+def buildArtifact = new BuildStage()
+def deployQa = new DeployStage('qa')
+def deployUat = new DeployStage('uat')
+def deployProd = new DeployStage('prod')
+
+pipeline.startsWith(buildArtifact)
+        .then(deployQa)
+        .then(deployUat)
+        .then(deployProd)
+        .build()
+```

--- a/src/BuildStage.groovy
+++ b/src/BuildStage.groovy
@@ -39,4 +39,8 @@ public class BuildStage implements Stage {
 
         return result
     }
+
+    public String getName() {
+        "build"
+    }
 }

--- a/src/BuildStage.groovy
+++ b/src/BuildStage.groovy
@@ -20,9 +20,7 @@ public class BuildStage implements Stage {
 
         return { ->
             decorations.apply() {
-                stage(getName()) {
-                    sh(getFullCommand())
-                }
+                sh(getFullCommand())
             }
         }
     }

--- a/src/BuildStage.groovy
+++ b/src/BuildStage.groovy
@@ -20,7 +20,7 @@ public class BuildStage implements Stage {
 
         return { ->
             decorations.apply() {
-                stage("build") {
+                stage(getName()) {
                     sh(getFullCommand())
                 }
             }

--- a/src/DeployStage.groovy
+++ b/src/DeployStage.groovy
@@ -16,7 +16,7 @@ public class DeployStage implements Stage {
         def stageEnvironment = environment
         return {
             decorations.apply() {
-                stage("deploy-${stageEnvironment}") {
+                stage(getName()) {
                     sh getFullDeployCommand()
                 }
             }

--- a/src/DeployStage.groovy
+++ b/src/DeployStage.groovy
@@ -51,4 +51,8 @@ public class DeployStage implements Stage {
 
         return fullCommand.toString()
     }
+
+    public String getName() {
+        return "deploy-${environment}"
+    }
 }

--- a/src/DeployStage.groovy
+++ b/src/DeployStage.groovy
@@ -16,9 +16,7 @@ public class DeployStage implements Stage {
         def stageEnvironment = environment
         return {
             decorations.apply() {
-                stage(getName()) {
-                    sh getFullDeployCommand()
-                }
+                sh getFullDeployCommand()
             }
         }
     }

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -14,8 +14,8 @@ public class Jenkinsfile implements Resettable {
         ScmPlugin.init()
         DefaultEnvironmentPlugin.init()
         NodePlugin.init()
-        StageDisplayPlugin.init()
         ConfirmBeforeDeployPlugin.init()
+        StageDisplayPlugin.init()
     }
 
     public static getInstance() {

--- a/src/Jenkinsfile.groovy
+++ b/src/Jenkinsfile.groovy
@@ -14,6 +14,7 @@ public class Jenkinsfile implements Resettable {
         ScmPlugin.init()
         DefaultEnvironmentPlugin.init()
         NodePlugin.init()
+        StageDisplayPlugin.init()
         ConfirmBeforeDeployPlugin.init()
     }
 

--- a/src/Stage.groovy
+++ b/src/Stage.groovy
@@ -1,4 +1,5 @@
 public interface Stage {
     public Closure pipelineConfiguration()
     public void decorate(Closure closure)
+    public String getName()
 }

--- a/src/StageDisplayPlugin.groovy
+++ b/src/StageDisplayPlugin.groovy
@@ -5,6 +5,10 @@ public class StageDisplayPlugin implements Plugin {
     }
 
     public void apply(Stage stage) {
-        println "Do the thing"
+        stage.decorate(stageClosure(stage))
+    }
+
+    public Closure stageClosure(Stage stage) {
+        return { }
     }
 }

--- a/src/StageDisplayPlugin.groovy
+++ b/src/StageDisplayPlugin.groovy
@@ -8,9 +8,9 @@ public class StageDisplayPlugin implements Plugin {
         stage.decorate(stageClosure(stage))
     }
 
-    public Closure stageClosure(Stage stage) {
+    public Closure stageClosure(Stage decoratedStage) {
         return { innerClosure ->
-            innerClosure()
+            stage(decoratedStage.getName(), innerClosure)
         }
     }
 }

--- a/src/StageDisplayPlugin.groovy
+++ b/src/StageDisplayPlugin.groovy
@@ -1,6 +1,7 @@
 public class StageDisplayPlugin implements Plugin {
     public static void init() {
         StagePlugins.add(new StageDisplayPlugin(), BuildStage)
+        StagePlugins.add(new StageDisplayPlugin(), DeployStage)
     }
 
     public void apply(Stage stage) {

--- a/src/StageDisplayPlugin.groovy
+++ b/src/StageDisplayPlugin.groovy
@@ -1,0 +1,9 @@
+public class StageDisplayPlugin implements Plugin {
+    public static void init() {
+        StagePlugins.add(new StageDisplayPlugin(), BuildStage)
+    }
+
+    public void apply(Stage stage) {
+        println "Do the thing"
+    }
+}

--- a/src/StageDisplayPlugin.groovy
+++ b/src/StageDisplayPlugin.groovy
@@ -1,4 +1,6 @@
-public class StageDisplayPlugin implements Plugin {
+public class StageDisplayPlugin implements Plugin, Resettable {
+    public static boolean disabled
+
     public static void init() {
         StagePlugins.add(new StageDisplayPlugin(), BuildStage)
         StagePlugins.add(new StageDisplayPlugin(), DeployStage)
@@ -10,11 +12,20 @@ public class StageDisplayPlugin implements Plugin {
 
     public Closure stageClosure(Stage decoratedStage) {
         return { innerClosure ->
-            stage(decoratedStage.getName(), innerClosure)
+            if (!disabled) {
+                stage(decoratedStage.getName(), innerClosure)
+            } else {
+                innerClosure()
+            }
         }
     }
 
     public static disable() {
+        disabled = true
         return this
+    }
+
+    public static void reset() {
+        disabled = false
     }
 }

--- a/src/StageDisplayPlugin.groovy
+++ b/src/StageDisplayPlugin.groovy
@@ -9,6 +9,8 @@ public class StageDisplayPlugin implements Plugin {
     }
 
     public Closure stageClosure(Stage stage) {
-        return { }
+        return { innerClosure ->
+            innerClosure()
+        }
     }
 }

--- a/src/StageDisplayPlugin.groovy
+++ b/src/StageDisplayPlugin.groovy
@@ -13,4 +13,8 @@ public class StageDisplayPlugin implements Plugin {
             stage(decoratedStage.getName(), innerClosure)
         }
     }
+
+    public static disable() {
+        return this
+    }
 }

--- a/test/BuildStageTest.groovy
+++ b/test/BuildStageTest.groovy
@@ -1,9 +1,7 @@
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.MatcherAssert.assertThat
-import static org.mockito.Mockito.any
 import static org.mockito.Mockito.doReturn
-import static org.mockito.Mockito.eq
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
 
@@ -50,18 +48,6 @@ class BuildStageTest {
             def result = buildStage.pipelineConfiguration()
 
             assertThat(result, instanceOf(Closure.class))
-        }
-
-        @Test
-        void createsAStageNamedBuild() {
-            def buildStage = new BuildStage()
-            def workflowScript = spy(new MockWorkflowScript())
-
-            def closure = buildStage.pipelineConfiguration()
-            closure.delegate = workflowScript
-            closure()
-
-            verify(workflowScript).stage(eq("build"), any(Closure.class))
         }
 
         @Test

--- a/test/BuildStageTest.groovy
+++ b/test/BuildStageTest.groovy
@@ -128,4 +128,17 @@ class BuildStageTest {
             assertThat(result, equalTo("${expectedPrefix} ./bin/build.sh".toString()))
         }
     }
+
+    @Nested
+    public class GetName {
+        @Test
+        void returnsAStageName() {
+            def expectedName = "build"
+            def stage = new BuildStage()
+
+            def result = stage.getName()
+
+            assertThat(result, equalTo(expectedName))
+        }
+    }
 }

--- a/test/DeployStageTest.groovy
+++ b/test/DeployStageTest.groovy
@@ -1,9 +1,7 @@
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.instanceOf
 import static org.hamcrest.MatcherAssert.assertThat
-import static org.mockito.Mockito.any
 import static org.mockito.Mockito.doReturn
-import static org.mockito.Mockito.eq
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
 
@@ -27,18 +25,6 @@ class DeployStageTest {
 
             def result = deployStage.pipelineConfiguration()
             assertThat(result, instanceOf(Closure.class))
-        }
-
-        @Test
-        void createsAStageNamedAfterTheEnvironment() {
-            def deployStage = new DeployStage('qa')
-            def workflowScript = spy(new MockWorkflowScript())
-
-            def pipelineConfiguration = deployStage.pipelineConfiguration()
-            pipelineConfiguration.delegate = workflowScript
-            pipelineConfiguration()
-
-            verify(workflowScript).stage(eq("deploy-qa"), any(Closure.class))
         }
 
         @Test

--- a/test/DeployStageTest.groovy
+++ b/test/DeployStageTest.groovy
@@ -150,4 +150,18 @@ class DeployStageTest {
             }
         }
     }
+
+    @Nested
+    public class GetName {
+        @Test
+        void returnsStageNameThatIncludesEnvironment() {
+            def environment = 'foo'
+            def expectedName = "deploy-${environment}".toString()
+
+            def stage = new DeployStage(environment)
+            def result = stage.getName()
+
+            assertThat(result, equalTo(expectedName))
+        }
+    }
 }

--- a/test/JenkinsfileTest.groovy
+++ b/test/JenkinsfileTest.groovy
@@ -42,6 +42,15 @@ class JenkinsfileTest {
             }
 
             @Test
+            public void enablesStageDisplayPlugin() {
+                Jenkinsfile.init(new MockWorkflowScript())
+
+                def plugins = StagePlugins.getPlugins()
+
+                assertThat(plugins, hasItem(StageDisplayPlugin))
+            }
+
+            @Test
             public void enablesNodePlugin() {
                 Jenkinsfile.init(new MockWorkflowScript())
 

--- a/test/StageDisplayPlugin.groovy
+++ b/test/StageDisplayPlugin.groovy
@@ -37,6 +37,15 @@ class StageDisplayPluginTest {
     }
 
     @Nested
+    public class Disable {
+        @Test
+        void isFluent() {
+            def result = StageDisplayPlugin.disable()
+            assertThat(result, equalTo(StageDisplayPlugin))
+        }
+    }
+
+    @Nested
     public class Apply {
         @Test
         void decoratesTheStageWithStageClosure() {

--- a/test/StageDisplayPlugin.groovy
+++ b/test/StageDisplayPlugin.groovy
@@ -1,7 +1,10 @@
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
+import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.verify
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -27,6 +30,21 @@ class StageDisplayPluginTest {
             def plugins = StagePlugins.getPluginsFor(mock(DeployStage.class))
 
             assertThat(plugins, hasItem(instanceOf(StageDisplayPlugin.class)))
+        }
+    }
+
+    @Nested
+    public class Apply {
+        @Test
+        void decoratesTheStageWithStageClosure() {
+            def expectedClosure = { }
+            def plugin = spy(new StageDisplayPlugin())
+            def stage = mock(Stage)
+            doReturn(expectedClosure).when(plugin).stageClosure(stage)
+
+            plugin.apply(stage)
+
+            verify(stage).decorate(expectedClosure)
         }
     }
 }

--- a/test/StageDisplayPlugin.groovy
+++ b/test/StageDisplayPlugin.groovy
@@ -2,7 +2,9 @@ import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
+import static org.mockito.Mockito.any
 import static org.mockito.Mockito.doReturn
+import static org.mockito.Mockito.eq
 import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
@@ -62,6 +64,21 @@ class StageDisplayPluginTest {
             closure(innerClosure)
 
             assertThat(wasCalled, equalTo(true))
+        }
+
+        @Test
+        void callsStageWithTheStageName() {
+            def expectedStageName = 'stageName'
+            def plugin = new StageDisplayPlugin()
+            def stage = mock(Stage)
+            doReturn(expectedStageName).when(stage).getName()
+            def workflowScript = spy(new MockWorkflowScript())
+
+            def closure = plugin.stageClosure(stage)
+            closure.delegate = workflowScript
+            closure { }
+
+            verify(workflowScript).stage(eq(expectedStageName), any(Closure))
         }
     }
 }

--- a/test/StageDisplayPlugin.groovy
+++ b/test/StageDisplayPlugin.groovy
@@ -1,0 +1,23 @@
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.instanceOf
+import static org.mockito.Mockito.mock
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ResetStaticStateExtension.class)
+class StageDisplayPluginTest {
+    @Nested
+    public class Init {
+        @Test
+        void addsPluginToTheBuildStage() {
+            StageDisplayPlugin.init()
+
+            def plugins = StagePlugins.getPluginsFor(mock(BuildStage.class))
+
+            assertThat(plugins, hasItem(instanceOf(StageDisplayPlugin.class)))
+        }
+    }
+}

--- a/test/StageDisplayPlugin.groovy
+++ b/test/StageDisplayPlugin.groovy
@@ -1,4 +1,5 @@
 import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.instanceOf
 import static org.mockito.Mockito.doReturn
@@ -45,6 +46,22 @@ class StageDisplayPluginTest {
             plugin.apply(stage)
 
             verify(stage).decorate(expectedClosure)
+        }
+    }
+
+    @Nested
+    public class StageClosure {
+        @Test
+        void callsTheInnerClosure() {
+            def wasCalled = false
+            def innerClosure = { wasCalled = true }
+            def plugin = new StageDisplayPlugin()
+
+            def closure = plugin.stageClosure(mock(Stage))
+            closure.delegate = new MockWorkflowScript()
+            closure(innerClosure)
+
+            assertThat(wasCalled, equalTo(true))
         }
     }
 }

--- a/test/StageDisplayPlugin.groovy
+++ b/test/StageDisplayPlugin.groovy
@@ -19,5 +19,14 @@ class StageDisplayPluginTest {
 
             assertThat(plugins, hasItem(instanceOf(StageDisplayPlugin.class)))
         }
+
+        @Test
+        void addsPluginToTheDeployStage() {
+            StageDisplayPlugin.init()
+
+            def plugins = StagePlugins.getPluginsFor(mock(DeployStage.class))
+
+            assertThat(plugins, hasItem(instanceOf(StageDisplayPlugin.class)))
+        }
     }
 }

--- a/test/StagePluginsTest.groovy
+++ b/test/StagePluginsTest.groovy
@@ -85,10 +85,12 @@ class StagePluginsTest {
     private class Stage1 implements Stage {
         public Closure pipelineConfiguration() { return { } }
         public void decorate(Closure closure) { return }
+        public String getName() { return "stage1" }
     }
 
     private class Stage2 implements Stage {
         public Closure pipelineConfiguration() { return { } }
         public void decorate(Closure closure) { return }
+        public String getName() { return "stage2" }
     }
 }


### PR DESCRIPTION
`node { }` and `scm` were previous hardcoded in BuildStage/DeployStage, then were refactored into Plugins, to provide more flexibility.  Let's do the same for `stage { }`.  This is a prereq for Issue #71 

## Merge Checklist

* [x] Have you linked this Pull Request to an [Issue](https://github.com/manheim/jenkinsfile-pipeline/issues)?
* [x] Have you updated any relevant README files, to explain how this new feature works (with examples)?
* [x] Have you added relevant test cases for your change?
* [x] Do all tests and code style checks pass with `./gradlew check --info`?
* [x] Have you successfully run your change in a pipeline in a Jenkins instance?
* [x] Have you updated the [CHANGELOG](https://github.com/manheim/jenkinsfile-pipeline/blob/master/CHANGELOG.md)?
